### PR TITLE
set up chrony to use amazon time sync

### DIFF
--- a/install-worker.sh
+++ b/install-worker.sh
@@ -62,7 +62,7 @@ sudo apt-get install -y \
     jq \
     nfs-kernel-server
 #@sinneduy: we will skip this for now, it looks like it overrides ssh configs.
-#ec2-instance-connect
+    #ec2-instance-connect
 
 ################################################################################
 ### Time #######################################################################
@@ -72,11 +72,19 @@ sudo apt-get install -y \
 update-rc.d chrony defaults 80 20
 
 # Make sure that chronyd syncs RTC clock to the kernel.
-cat <<EOF | sudo tee -a /etc/chrony.conf
-# This directive enables kernel synchronisation (every 11 minutes) of the
-# real-time clock. Note that it can’t be used along with the 'rtcfile' directive.
-rtcsync
-EOF
+# This can be commented out because this is set in the chrony config by default
+#cat <<EOF | sudo tee -a /etc/chrony.conf
+## This directive enables kernel synchronisation (every 11 minutes) of the
+## real-time clock. Note that it can’t be used along with the 'rtcfile' directive.
+#rtcsync
+#EOF
+
+# However, chrony does not use Amazon Time Sync Service by default in Ubuntu
+# So, we will have to configure it to prefer it according to this:
+# https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/set-time.html#configure-amazon-time-service-ubuntu
+
+sudo sed -i '1s/^/server 169.254.169.123 prefer iburst minpoll 4 maxpoll 4\n/' /etc/chrony/chrony.conf
+
 
 # If current clocksource is xen, switch to tsc
 # @sinneduy: This probably won't work in ubuntu, should probably try to validate it later


### PR DESCRIPTION
@sinneduy and I validated that this set up chrony to use Amazon Time Sync:

```
ubuntu@ip-10-10-75-99:~$ cat /etc/chrony/chrony.conf
server 169.254.169.123 prefer iburst minpoll 4 maxpoll 4
# Welcome to the chrony configuration file. See chrony.conf(5) for more
# information about usuable directives.

# This will use (up to):
# - 4 sources from ntp.ubuntu.com which some are ipv6 enabled
# - 2 sources from 2.ubuntu.pool.ntp.org which is ipv6 enabled as well
# - 1 source from [01].ubuntu.pool.ntp.org each (ipv4 only atm)
# This means by default, up to 6 dual-stack and up to 2 additional IPv4-only
# sources will be used.
# At the same time it retains some protection against one of the entries being
# down (compare to just using one of the lines). See (LP: #1754358) for the
# discussion.
#
# About using servers from the NTP Pool Project in general see (LP: #104525).
# Approved by Ubuntu Technical Board on 2011-02-08.
# See http://www.pool.ntp.org/join.html for more information.
pool ntp.ubuntu.com        iburst maxsources 4
pool 0.ubuntu.pool.ntp.org iburst maxsources 1
pool 1.ubuntu.pool.ntp.org iburst maxsources 1
pool 2.ubuntu.pool.ntp.org iburst maxsources 2

# This directive specify the location of the file containing ID/key pairs for
# NTP authentication.
keyfile /etc/chrony/chrony.keys

# This directive specify the file into which chronyd will store the rate
# information.
driftfile /var/lib/chrony/chrony.drift

# Uncomment the following line to turn logging on.
#log tracking measurements statistics

# Log files location.
logdir /var/log/chrony

# Stop bad estimates upsetting machine clock.
maxupdateskew 100.0

# This directive enables kernel synchronisation (every 11 minutes) of the
# real-time clock. Note that it can’t be used along with the 'rtcfile' directive.
rtcsync

# Step the system clock instead of slewing it if the adjustment is larger than
# one second, but only in the first three clock updates.
makestep 1 3
ubuntu@ip-10-10-75-99:~$ chronyc sources -v
210 Number of sources = 1

  .-- Source mode  '^' = server, '=' = peer, '#' = local clock.
 / .- Source state '*' = current synced, '+' = combined , '-' = not combined,
| /   '?' = unreachable, 'x' = time may be in error, '~' = time too variable.
||                                                 .- xxxx [ yyyy ] +/- zzzz
||      Reachability register (octal) -.           |  xxxx = adjusted offset,
||      Log2(Polling interval) --.      |          |  yyyy = measured offset,
||                                \     |          |  zzzz = estimated error.
||                                 |    |           \
MS Name/IP address         Stratum Poll Reach LastRx Last sample
===============================================================================
^* 169.254.169.123               3   4   177     3  -8825ns[ -115us] +/-  218us
```

However, its pretty weird that it doesn't have any other ips to pool from - do you think that's okay?

cc @szarya 

When we added the Amazon Time to an already running instance, we saw that it had the Amazon Time Sync server as preferred, but still had a number of other servers listed (as backup maybe?)

```
lucy.lufei@eks-payroll-staging-i-0285d2ee3cf56ad5b:~$ chronyc sources -v
210 Number of sources = 9

  .-- Source mode  '^' = server, '=' = peer, '#' = local clock.
 / .- Source state '*' = current synced, '+' = combined , '-' = not combined,
| /   '?' = unreachable, 'x' = time may be in error, '~' = time too variable.
||                                                 .- xxxx [ yyyy ] +/- zzzz
||      Reachability register (octal) -.           |  xxxx = adjusted offset,
||      Log2(Polling interval) --.      |          |  yyyy = measured offset,
||                                \     |          |  zzzz = estimated error.
||                                 |    |           \
MS Name/IP address         Stratum Poll Reach LastRx Last sample
===============================================================================
^* 169.254.169.123               3   4   377    14  -7149ns[-6446ns] +/-  135us
^- pugot.canonical.com           2   6   357    63  -1540us[-1539us] +/-  122ms
^- alphyn.canonical.com          2   6   377    66  -1128us[-1127us] +/-  110ms
^- chilipepper.canonical.com     2   6   356   258  -1487us[-1482us] +/-  107ms
^- golem.canonical.com           2   6   377    64  -1585us[-1584us] +/-   99ms
^- jitter.tickadj.net            2   6   377    65   -491us[ -490us] +/-   51ms
^- ellone.fdisk.io               2   6   377    64   +162us[ +163us] +/-   36ms
^- gw1.rbx.ip4.servme.fr         3   6   377    63  -1194us[-1193us] +/-  188ms
^- zero.gotroot.ca               2   6   377     1  -1818us[-1818us] +/-   16ms
```