### PR TITLE
add m6i ENI mac info

### DIFF
--- a/files/eni-max-pods.txt
+++ b/files/eni-max-pods.txt
@@ -265,6 +265,15 @@ m6gd.large 29
 m6gd.medium 8
 m6gd.metal 737
 m6gd.xlarge 58
+m6i.12xlarge 234
+m6i.16xlarge 737
+m6i.24xlarge 737
+m6i.2xlarge 58
+m6i.32xlarge 737
+m6i.4xlarge 234
+m6i.8xlarge 234
+m6i.large 29
+m6i.xlarge 58
 mac1.metal 234
 p2.16xlarge 234
 p2.8xlarge 234


### PR DESCRIPTION
This change adds max ENI details for the various m6i instances types.

This information was taken from [awslabs/amazon-eks-ami](https://github.com/awslabs/amazon-eks-ami/blob/master/files/eni-max-pods.txt#L270-L277).