### PR TITLE
Update install-worker.sh

### DIFF
--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -163,7 +163,7 @@ if [[ "$INSTALL_DOCKER" == "true" ]]; then
   sudo usermod -aG docker $USER
 
   # install condtainerd.io, which includes containerd and runc
-  sudo apt-get install -y containerd.io=${CONTAINERDIO_VERSION}
+  sudo apt-get install -y containerd.io=${CONTAINERDIO_VERSION} --allow-downgrades
 
   sudo mkdir -p /etc/docker
   sudo mv $TEMPLATE_DIR/docker-daemon.json /etc/docker/daemon.json


### PR DESCRIPTION
temporarily allow downgrades because apt has a new version of containerd (1.5.x) but awslabs has not yet jumped to it.  awslabs is currently on 1.4.2 (which is a minor version higher, but it looks like it doesn't exist in apt)